### PR TITLE
Adds a flag to RequestFrame to specify a Think hook

### DIFF
--- a/core/TimerSys.cpp
+++ b/core/TimerSys.cpp
@@ -242,6 +242,11 @@ void TimerSystem::GameFrame(bool simulating)
 	}
 }
 
+void TimerSystem::Think(bool FinalTick)
+{
+	RunThinkHooks(FinalTick);
+}
+
 void TimerSystem::RunFrame()
 {
 	ITimer *pTimer;

--- a/core/TimerSys.h
+++ b/core/TimerSys.h
@@ -83,6 +83,7 @@ public:
 	void RunFrame();
 	void RemoveMapChangeTimers();
 	void GameFrame(bool simulating);
+	void Think(bool FinalTick);
 private:
 	List<ITimer *> m_SingleTimers;
 	List<ITimer *> m_LoopTimers;

--- a/core/frame_hooks.h
+++ b/core/frame_hooks.h
@@ -50,4 +50,7 @@ extern bool g_PendingInternalPush;
 void AddFrameAction(const FrameAction & action);
 void RunFrameHooks(bool simulating);
 
+void AddThinkAction(const FrameAction & action);
+void RunThinkHooks(bool FinalTick);
+
 #endif //_INCLUDE_SOURCEMOD_FRAME_HOOKS_H_

--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -645,7 +645,15 @@ static cell_t sm_AddFrameAction(IPluginContext *pContext, const cell_t *params)
 	pForward->AddFunction(pFunction);
 
 	SMFrameActionData *pData = new SMFrameActionData(Handle, pPlugin->GetMyHandle(), params[2]);
-	g_pSM->AddFrameAction(PawnFrameAction, pData);
+	if (params[0] >= 3)	//for backwards compatibility
+	{
+		if (params[3]) { g_pSM->AddThinkAction(PawnFrameAction, pData); }
+		else { g_pSM->AddFrameAction(PawnFrameAction, pData); }
+	}
+	else
+	{
+		g_pSM->AddFrameAction(PawnFrameAction, pData);
+	}
 	return 1;
 }
 

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -254,6 +254,7 @@ void SourceModBase::StartSourceMod(bool late)
 {
 	SH_ADD_HOOK(IServerGameDLL, LevelShutdown, gamedll, SH_MEMBER(this, &SourceModBase::LevelShutdown), false);
 	SH_ADD_HOOK(IServerGameDLL, GameFrame, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::GameFrame), false);
+	SH_ADD_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::Think), false);
 
 	enginePatch = SH_GET_CALLCLASS(engine);
 	gamedllPatch = SH_GET_CALLCLASS(gamedll);
@@ -543,6 +544,7 @@ void SourceModBase::ShutdownServices()
 
 	SH_REMOVE_HOOK(IServerGameDLL, LevelShutdown, gamedll, SH_MEMBER(this, &SourceModBase::LevelShutdown), false);
 	SH_REMOVE_HOOK(IServerGameDLL, GameFrame, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::GameFrame), false);
+	SH_REMOVE_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::Think), false);
 	SH_REMOVE_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(logicore.callbacks, &IProviderCallbacks::OnThink), false);
 }
 
@@ -720,6 +722,11 @@ size_t SourceModBase::FormatArgs(char *buffer,
 void SourceModBase::AddFrameAction(FRAMEACTION fn, void *data)
 {
 	::AddFrameAction(FrameAction(fn, data));
+}
+
+void SourceModBase::AddThinkAction(FRAMEACTION fn, void *data)
+{
+	::AddThinkAction(FrameAction(fn, data));
 }
 
 const char *SourceModBase::GetCoreConfigValue(const char *key)

--- a/core/sourcemod.h
+++ b/core/sourcemod.h
@@ -131,6 +131,7 @@ public: // ISourceMod
 	size_t Format(char *buffer, size_t maxlength, const char *fmt, ...);
 	size_t FormatArgs(char *buffer, size_t maxlength, const char *fmt, va_list ap);
 	void AddFrameAction(FRAMEACTION fn, void *data);
+	void AddThinkAction(FRAMEACTION fn, void *data);
 	const char *GetCoreConfigValue(const char *key);
 	int GetPluginId();
 	int GetShApiVersion();

--- a/plugins/include/functions.inc
+++ b/plugins/include/functions.inc
@@ -500,6 +500,8 @@ typedef RequestFrameCallback = function void (any data);
  * Creates a single use Next Frame hook.
  *
  * @param Function	Function to call on the next frame.
- * @param data			Value to be passed on the invocation of the Function.
+ * @param data		Value to be passed on the invocation of the Function.
+ * @param HookThink	Enable this flag if you want your function to be called 
+ *					even if the server is hibernating.
  */
-native void RequestFrame(RequestFrameCallback Function, any data=0);
+native void RequestFrame(RequestFrameCallback Function, any data=0, bool HookThink=false);

--- a/public/ISourceMod.h
+++ b/public/ISourceMod.h
@@ -289,6 +289,16 @@ namespace SourceMod
 		virtual void AddFrameAction(FRAMEACTION fn, void *data) = 0;
 
 		/**
+		* @brief Adds an action to be executed on the next available think call.
+		*
+		* This function is thread safe.
+		*
+		* @param fn			Function to execute.
+		* @param data		Data to pass to function.
+		*/
+		virtual void AddThinkAction(FRAMEACTION fn, void *data) = 0;
+
+		/**
 		 * @brief Retrieves a core.cfg configuration value.
 		 *
 		 * @param key		Core.cfg key phrase.


### PR DESCRIPTION
Added AddThinkAction to the sm interface and a flag to RequestFrame on
pawn to specify a Think hook instead of a GameFrame one. This allows
plguins to schedule actions to be executed on the next think call, even
if the server is hibernating.

Status: the branch builds no problem but it generates a runtime error
while trying to load the sdktools and sdkhooks extensions ("Unable to
load extension "sdkhooks.ext": undefined symbol: Warning" and "Unable to
load extension "sdktools.ext": undefined symbol: Warning") any help
would be appreciated.
